### PR TITLE
Allow skipping of Welcome on programattic activation

### DIFF
--- a/strong-testimonials.php
+++ b/strong-testimonials.php
@@ -159,7 +159,7 @@ final class Strong_Testimonials {
 		wpmtst_register_cpt();
 		flush_rewrite_rules();
 		
-		if (!defined('STRONG_TESTIMONIALS_PROGRAMMATIC_ACTIVATION')) {
+		if (class_exists('Strong_Testimonials_Welcome')) {
 			new Strong_Testimonials_Welcome();
 			do_action( 'wpmtst_after_update_setup', $first_install );	
 		}

--- a/strong-testimonials.php
+++ b/strong-testimonials.php
@@ -159,8 +159,10 @@ final class Strong_Testimonials {
 		wpmtst_register_cpt();
 		flush_rewrite_rules();
 		
-		new Strong_Testimonials_Welcome();
-		do_action( 'wpmtst_after_update_setup', $first_install );
+		if (!defined('STRONG_TESTIMONIALS_PROGRAMMATIC_ACTIVATION')) {
+			new Strong_Testimonials_Welcome();
+			do_action( 'wpmtst_after_update_setup', $first_install );	
+		}
 	}
 
 	/**


### PR DESCRIPTION
For #347

There, I had suggested putting a value in the database. It seems better to use a constant.

I named it prefixed with `STRONG_TESTIMONIALS`, as opposed to `WPMTST`, thinking that `WPMTST` is perhaps meant for internal use and I shouldn't hijack it. But by all means, feel free to change it.